### PR TITLE
feat(collision): implement CollisionSystem and integrate with Scene

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,9 +12,9 @@
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug",
-            "executable": "D:/_data/projets/embedded/ESP32 Game Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
+            "executable": "c:/Users/gperez88/Documents/ESP32-Game-Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
             "projectEnvName": "dfrobot_beetle_esp32c3",
-            "toolchainBinDir": "C:/Users/nicol/.platformio/packages/toolchain-riscv32-esp/bin",
+            "toolchainBinDir": "C:/Users/gperez88/.platformio/packages/toolchain-riscv32-esp/bin",
             "internalConsoleOptions": "openOnSessionStart",
             "preLaunchTask": {
                 "type": "PlatformIO",
@@ -25,18 +25,18 @@
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug (skip Pre-Debug)",
-            "executable": "D:/_data/projets/embedded/ESP32 Game Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
+            "executable": "c:/Users/gperez88/Documents/ESP32-Game-Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
             "projectEnvName": "dfrobot_beetle_esp32c3",
-            "toolchainBinDir": "C:/Users/nicol/.platformio/packages/toolchain-riscv32-esp/bin",
+            "toolchainBinDir": "C:/Users/gperez88/.platformio/packages/toolchain-riscv32-esp/bin",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "type": "platformio-debug",
             "request": "launch",
             "name": "PIO Debug (without uploading)",
-            "executable": "D:/_data/projets/embedded/ESP32 Game Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
+            "executable": "c:/Users/gperez88/Documents/ESP32-Game-Engine/.pio/build/dfrobot_beetle_esp32c3/firmware.elf",
             "projectEnvName": "dfrobot_beetle_esp32c3",
-            "toolchainBinDir": "C:/Users/nicol/.platformio/packages/toolchain-riscv32-esp/bin",
+            "toolchainBinDir": "C:/Users/gperez88/.platformio/packages/toolchain-riscv32-esp/bin",
             "internalConsoleOptions": "openOnSessionStart",
             "loadMode": "manual"
         }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ https://github.com/user-attachments/assets/466554af-29f4-4d50-976b-3db33ba87524
 
 ## Features
 - **Entity-based architecture** for modular game objects.
-- **Colission System** to handle interactions between entities in a centralized way.
+- **Collision System** to handle interactions between entities in a centralized way.
 - **Scene management** to handle game flow.
 - **Customizable renderer & input system** (supporting different devices).
 - **Optimized for embedded systems** (memory-efficient, no heap fragmentation).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Things can break at any update.
     - [Scenes](#scenes)
     - [Entities](#entities)
     - [Renderer \& DisplayConfig](#renderer--displayconfig)
+    - [Collision System](#collision-system)
   - [Project Structure](#project-structure)
   - [Setup \& Installation](#setup--installation)
     - [Hardware Requirements](#hardware-requirements)
@@ -44,6 +45,7 @@ https://github.com/user-attachments/assets/466554af-29f4-4d50-976b-3db33ba87524
 
 ## Features
 - **Entity-based architecture** for modular game objects.
+- **Colission System** to handle interactions between entities in a centralized way.
 - **Scene management** to handle game flow.
 - **Customizable renderer & input system** (supporting different devices).
 - **Optimized for embedded systems** (memory-efficient, no heap fragmentation).
@@ -63,6 +65,19 @@ EDGE is built around **scenes** and **entities**:
 ### Entities
 - Each **entity** is an object in the game (player, enemy, particle, etc.).
 - Entities **update every frame** and **draw themselves**.
+
+### Collision System
+
+EDGE now includes a **Collision System** to handle interactions between entities in a centralized way. This keeps collision logic clean and modular.
+
+- Each **Entity** can have a **HitBox** (rectangle or circle) defining its collision area.
+- The **CollisionSystem** is responsible for:
+  - Registering entities that participate in collisions.
+  - Checking intersections between all registered entities.
+  - Calling the `onCollision(Entity* other)` method on each colliding entity.
+
+Collision System Sample Implementation: `/examples/Pong`
+
 
 ### Renderer & DisplayConfig
 - The **Renderer** handles all drawing operations with `U8g2`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ EDGE is built around **scenes** and **entities**:
 
 EDGE now includes a **Collision System** to handle interactions between entities in a centralized way. This keeps collision logic clean and modular.
 
-- Each **Entity** can have a **HitBox** (rectangle or circle) defining its collision area.
+- Each **Entity** can have a **rectangular HitBox** defining its collision area.
 - The **CollisionSystem** is responsible for:
   - Registering entities that participate in collisions.
   - Checking intersections between all registered entities.

--- a/examples/Pong/BallEntity.cpp
+++ b/examples/Pong/BallEntity.cpp
@@ -1,0 +1,66 @@
+#include "BallEntity.h"
+#include "PaddleEntity.h"
+#include "EDGE.h"
+#include <stdlib.h>
+#include <math.h>
+
+extern EDGE engine;
+
+void BallEntity::reset() {
+    int screenWidth = engine.getRenderer().getWidth();
+    int screenHeight = engine.getRenderer().getHeight();
+
+    x = screenWidth / 2.0f;
+    y = screenHeight / 2.0f;
+
+    vx = 0;
+    vy = 0;
+    respawnTimer = 500;
+    active = false;
+}
+
+void BallEntity::update(unsigned long deltaTime) {
+    float dt = deltaTime / 1000.0f;
+
+    if (!active) {
+        if (respawnTimer > deltaTime) {
+            respawnTimer -= deltaTime;
+            return;
+        } else {
+   
+            respawnTimer = 0;
+            active = true;
+
+            vx = (rand() % 2 == 0 ? 1 : -1) * speed;
+            vy = ((rand() % 100) / 100.0f - 0.5f) * speed;
+        }
+    }
+
+    x += vx * dt;
+    y += vy * dt;
+
+    int screenHeight = engine.getRenderer().getHeight();
+
+    if (y - radius < 0) { y = radius; vy = -vy; }
+    if (y + radius > screenHeight) { y = screenHeight - radius; vy = -vy; }
+}
+
+void BallEntity::draw(Renderer& renderer) {
+    renderer.drawCircle((int)x, (int)y, radius);
+}
+
+void BallEntity::onCollision(Entity* other) {
+    PaddleEntity* paddle = dynamic_cast<PaddleEntity*>(other);
+    if (paddle) {
+        vx = -vx;
+
+        if (vx > 0) {
+            x = paddle->x + paddle->width + radius;
+        } else {
+            x = paddle->x - radius;
+        }
+
+        float impactPos = (y - paddle->y) / paddle->height - 0.5f;
+        vy += impactPos * 50.0f;
+    }
+}

--- a/examples/Pong/BallEntity.h
+++ b/examples/Pong/BallEntity.h
@@ -18,5 +18,5 @@ public:
 
     Rect getHitBox() override { return {x-radius, y-radius, radius*2, radius*2}; }
 
-    void onCollision(Entity* other);
+    void onCollision(Entity* other) override;
 };

--- a/examples/Pong/BallEntity.h
+++ b/examples/Pong/BallEntity.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "Entity.h"
+
+class BallEntity : public Entity  {
+public:
+    float x, y, vx, vy;
+    float speed;
+    int radius;
+    unsigned long respawnTimer;   // respawn delay timer
+    bool active;                  // is active
+
+    BallEntity(float x, float y, int radius, float speed)
+        : x(x), y(y), vx(0), vy(0), radius(radius), speed(speed), respawnTimer(0), active(false) {}
+    void reset();
+
+    void update(unsigned long deltaTime) override;
+    void draw(Renderer& renderer) override;
+
+    Rect getHitBox() override { return {x-radius, y-radius, radius*2, radius*2}; }
+
+    void onCollision(Entity* other);
+};

--- a/examples/Pong/PaddleEntity.cpp
+++ b/examples/Pong/PaddleEntity.cpp
@@ -1,0 +1,65 @@
+#include "PaddleEntity.h"
+#include "PongScene.h"  
+#include "EDGE.h"
+#include <math.h>
+extern EDGE engine;
+
+// Constantes AI
+#define AI_TARGET_OFFSET 6.0f
+#define AI_MAX_SPEED 90.0f
+#define AI_MOVEMENT_THRESHOLD 0.5f
+#define PONG_PLAY_AREA_TOP 0
+#define PONG_PLAY_AREA_BOTTOM engine.getRenderer().getHeight()
+
+void PaddleEntity::update(unsigned long deltaTime) {
+    float dt = deltaTime / 1000.0f;
+    
+    if (isAI) {
+        // AI movement
+        PongScene* pongScene = dynamic_cast<PongScene*>(engine.getCurrentScene());
+
+        if (pongScene) {
+            float ballX = pongScene->getBallX();
+            float ballY = pongScene->getBallY();
+
+            float paddleCenterY = y + height / 2.0f;
+            float diff = ballY - paddleCenterY;
+
+
+            // Small offset for AI
+            static uint32_t aiOffsetSeed = 0;
+            if (AI_TARGET_OFFSET > 0.0f) {
+                if (aiOffsetSeed == 0) aiOffsetSeed = millis();
+                float offset = ((float)((aiOffsetSeed + (uint32_t)(ballX*5) + (uint32_t)(millis()/150)) % 200) / 200.0f - 0.5f) * AI_TARGET_OFFSET;
+                diff += offset;
+                aiOffsetSeed++;
+            }
+
+            float proportionalSpeed = diff * 1.5f;
+            if (proportionalSpeed > AI_MAX_SPEED) proportionalSpeed = AI_MAX_SPEED;
+            else if (proportionalSpeed < -AI_MAX_SPEED) proportionalSpeed = -AI_MAX_SPEED;
+
+            if (fabsf(diff) > AI_MOVEMENT_THRESHOLD) accumulator += proportionalSpeed * dt;
+
+            if (accumulator >= 1.0f) { int m = (int)accumulator; y += m; accumulator -= m; }
+            else if (accumulator <= -1.0f) { int m = (int)accumulator; y += m; accumulator -= m; }
+
+        }
+
+    } else {
+        // Player movement
+        y += velocity * dt;
+    }
+
+    // Keep inside play area
+    if (y < 0) { y = 0; accumulator = 0; }
+    if (y + height > PONG_PLAY_AREA_BOTTOM) { y = PONG_PLAY_AREA_BOTTOM - height; accumulator = 0; }
+}
+
+void PaddleEntity::draw(Renderer& renderer) {
+    renderer.drawFilledRectangle((int)x, (int)y, width, height);
+}
+
+void PaddleEntity::onCollision(Entity* other) {
+    // No special collision handling needed for paddles
+}

--- a/examples/Pong/PaddleEntity.h
+++ b/examples/Pong/PaddleEntity.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Entity.h"
+
+class PaddleEntity : public Entity  {
+public:
+    float x, y;
+    int width, height;
+    float velocity;      // for player movement
+    float accumulator;   // for AI movement
+    bool isAI;
+
+    PaddleEntity(float x, float y, int w, int h, bool ai = false)
+        : x(x), y(y), width(w), height(h), velocity(0), accumulator(0), isAI(ai) {}
+
+    void update(unsigned long deltaTime) override;
+    void draw(Renderer& renderer) override;
+
+    Rect getHitBox() override { return {x, y, width, height}; }
+
+    void onCollision(Entity* other) override;
+};

--- a/examples/Pong/Pong.ino
+++ b/examples/Pong/Pong.ino
@@ -1,0 +1,33 @@
+#include <Arduino.h>
+#include "EDGE.h"
+#include "PongScene.h"
+
+#define I2C_SDA SDA
+#define I2C_SCL SCL
+#define SCREEN_WIDTH 72
+#define SCREEN_HEIGHT 40
+
+// Examples ESP32-C3 with OLED Display
+DisplayConfig config(SSD1306, U8G2_R0, I2C_SCL, I2C_SDA, U8X8_PIN_NONE, U8X8_PIN_NONE, U8X8_PIN_NONE, SCREEN_WIDTH, SCREEN_HEIGHT, true);
+InputConfig inputConfig(2, 0, 1); // Two button connected to pin 0 and 1
+
+EDGE engine(config, inputConfig);
+PongScene scene;
+
+unsigned long currentTime = 0;
+
+void printTask(ulong time);
+
+void setup() {
+    Serial.begin(115200);
+    engine.init();
+    engine.setScene(&scene);
+
+    Serial.println("Setup completed");
+}
+
+void loop() {
+    currentTime = millis();
+    engine.update();
+    engine.draw();
+}

--- a/examples/Pong/PongScene.cpp
+++ b/examples/Pong/PongScene.cpp
@@ -39,7 +39,7 @@ void PongScene::update(unsigned long deltaTime) {
         ball->update(deltaTime);
 
         // --- Collisions between entities ---
-        collisionSystem.update();
+        // Collision handling is performed by the base Scene::update
 
         // --- Check if ball is out of bounds ---
         if (ball->x < 0) {       // left side

--- a/examples/Pong/PongScene.cpp
+++ b/examples/Pong/PongScene.cpp
@@ -33,10 +33,8 @@ void PongScene::update(unsigned long deltaTime) {
         if (engine.getInputManager().isButtonDown(0)) leftPaddle->velocity = -100.0f;
         if (engine.getInputManager().isButtonDown(1)) leftPaddle->velocity = 100.0f;
 
-        // --- Update actors ---
-        leftPaddle->update(deltaTime);
-        rightPaddle->update(deltaTime);
-        ball->update(deltaTime);
+        // --- Update all entities via base Scene ---
+        Scene::update(deltaTime);
 
         // --- Collisions between entities ---
         // Collision handling is performed by the base Scene::update

--- a/examples/Pong/PongScene.cpp
+++ b/examples/Pong/PongScene.cpp
@@ -1,0 +1,85 @@
+#include "PongScene.h"
+#include "EDGE.h"
+extern EDGE engine;
+
+#define PADDLE_WIDTH 10
+#define PADDLE_HEIGHT 50
+#define BALL_RADIUS 6
+#define BALL_SPEED 120.0f
+#define SCORE_TO_WIN 5
+
+void PongScene::init() {
+    int screenWidth = engine.getRenderer().getWidth();
+    int screenHeight = engine.getRenderer().getHeight();
+
+    leftPaddle = new PaddleEntity(0, screenHeight/2 - PADDLE_HEIGHT/2, PADDLE_WIDTH, PADDLE_HEIGHT, false);
+    rightPaddle = new PaddleEntity(screenWidth - PADDLE_WIDTH, screenHeight/2 - PADDLE_HEIGHT/2, PADDLE_WIDTH, PADDLE_HEIGHT, true);
+    ball = new BallEntity(screenWidth/2, screenHeight/2, BALL_RADIUS, BALL_SPEED);
+    ball->reset();
+
+    addEntity(leftPaddle);
+    addEntity(rightPaddle);
+    addEntity(ball);
+
+    leftScore = 0;
+    rightScore = 0;
+    gameOver = false;
+}
+
+void PongScene::update(unsigned long deltaTime) {
+    if (!gameOver) {
+        // --- Input Player ---
+        leftPaddle->velocity = 0;
+        if (engine.getInputManager().isButtonDown(0)) leftPaddle->velocity = -100.0f;
+        if (engine.getInputManager().isButtonDown(1)) leftPaddle->velocity = 100.0f;
+
+        // --- Update actors ---
+        leftPaddle->update(deltaTime);
+        rightPaddle->update(deltaTime);
+        ball->update(deltaTime);
+
+        // --- Collisions between entities ---
+        collisionSystem.update();
+
+        // --- Check if ball is out of bounds ---
+        if (ball->x < 0) {       // left side
+            rightScore++;
+            ball->reset();
+        }
+        if (ball->x > engine.getRenderer().getWidth()) { // right side
+            leftScore++;
+            ball->reset();
+        }
+
+        // --- Game Over ---
+        if (leftScore >= SCORE_TO_WIN || rightScore >= SCORE_TO_WIN) {
+            gameOver = true;
+        }
+
+    } else {
+        if (engine.getInputManager().isButtonPressed(0)) resetGame();
+    }
+}
+
+void PongScene::draw(Renderer& renderer) {
+    // draw scores
+    renderer.drawTextSafe(20, 8, "%d", leftScore);
+    renderer.drawTextSafe(engine.getRenderer().getWidth() - 30, 8, "%d", rightScore);
+
+    if (gameOver) {
+        // draw game over message
+        renderer.drawTextSafe(engine.getRenderer().getWidth()/2 - 40,
+                              engine.getRenderer().getHeight()/2,
+                              "GAME OVER!");
+    }
+
+    // draw entities (paddles and ball)
+    Scene::draw(renderer);
+}
+
+void PongScene::resetGame() {
+    leftScore = 0;
+    rightScore = 0;
+    gameOver = false;
+    ball->reset();
+}

--- a/examples/Pong/PongScene.h
+++ b/examples/Pong/PongScene.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "Scene.h"
+#include "PaddleEntity.h"
+#include "BallEntity.h"
+
+class PongScene : public Scene {
+public:
+    void init() override;
+    void update(unsigned long deltaTime) override;
+    void draw(Renderer& renderer) override;
+
+    float getBallX() { return ball->x; }
+    float getBallY() { return ball->y; }
+
+private:
+    PaddleEntity* leftPaddle;
+    PaddleEntity* rightPaddle;
+    BallEntity* ball;
+
+    int leftScore, rightScore;
+    bool gameOver;
+
+    void resetGame();
+};

--- a/src/CollisionSystem.cpp
+++ b/src/CollisionSystem.cpp
@@ -1,0 +1,17 @@
+#include "CollisionSystem.h"
+
+void CollisionSystem::addEntity(Entity* e) { entities.push_back(e); }
+void CollisionSystem::removeEntity(Entity* e) { 
+    entities.erase(std::remove(entities.begin(), entities.end(), e), entities.end());
+}
+
+void CollisionSystem::update() {
+    for (size_t i = 0; i < entities.size(); i++) {
+        for (size_t j = i + 1; j < entities.size(); j++) {
+            if (entities[i]->getHitBox().intersects(entities[j]->getHitBox())) {
+                entities[i]->onCollision(entities[j]);
+                entities[j]->onCollision(entities[i]);
+            }
+        }
+    }
+}

--- a/src/CollisionSystem.h
+++ b/src/CollisionSystem.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <vector>
+#include <algorithm>
+#include "Entity.h"
+
+class CollisionSystem {
+public:
+    void addEntity(Entity* e);
+    void removeEntity(Entity* e);
+    void update();
+
+private:
+    std::vector<Entity*> entities;
+};

--- a/src/EDGE.h
+++ b/src/EDGE.h
@@ -26,6 +26,7 @@ public:
     
     // Scene management via SceneManager
     void setScene(Scene* newScene);
+    Scene* getCurrentScene() const { return sceneManager.getCurrentScene(); }
     
     void setRenderer(Renderer& newRenderer) { renderer = newRenderer; }
     Renderer& getRenderer();

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -1,9 +1,22 @@
 #pragma once
 #include "Renderer.h"
 
+struct Rect {
+    float x, y;
+    int width, height;
+
+    bool intersects(const Rect& other) const {
+        return !(x + width < other.x || x > other.x + other.width ||
+                 y + height < other.y || y > other.y + other.height);
+    }
+};
+
 class Entity {
 public:
     virtual ~Entity() {}
-    virtual void update(unsigned long deltaTime) = 0;
+    virtual void update(unsigned long deltaTimet) = 0;
     virtual void draw(Renderer& renderer) = 0;
+
+    virtual Rect getHitBox() = 0;
+    virtual void onCollision(Entity* other) = 0;
 };

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -14,7 +14,7 @@ struct Rect {
 class Entity {
 public:
     virtual ~Entity() {}
-    virtual void update(unsigned long deltaTimet) = 0;
+    virtual void update(unsigned long deltaTime) = 0;
     virtual void draw(Renderer& renderer) = 0;
 
     virtual Rect getHitBox() = 0;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -8,7 +8,7 @@ void Scene::update(unsigned long deltaTime) {
         entities.enqueue(entity);  // Re-add entity to maintain order
     }
 
-    //  update collision system after remoeving all entities
+    //  update collision system after removing all entities
     collisionSystem.update();
 }
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -7,6 +7,9 @@ void Scene::update(unsigned long deltaTime) {
         entity->update(deltaTime);
         entities.enqueue(entity);  // Re-add entity to maintain order
     }
+
+    //  update collision system after remoeving all entities
+    collisionSystem.update();
 }
 
 void Scene::draw(Renderer& renderer) {
@@ -20,6 +23,7 @@ void Scene::draw(Renderer& renderer) {
 
 void Scene::addEntity(Entity* entity) {
     entities.enqueue(entity);
+    collisionSystem.addEntity(entity); // sync with collision system
 }
 
 void Scene::removeEntity(Entity* entity) {
@@ -28,6 +32,8 @@ void Scene::removeEntity(Entity* entity) {
         Entity* e = entities.dequeue();
         if (e != entity) {
             tempQueue.enqueue(e);  // Keep all except the one to remove
+        } else {
+            collisionSystem.removeEntity(e); // sync with collision system
         }
     }
     entities = tempQueue;

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ArduinoQueue.h>
+#include "CollisionSystem.h"
 #include "Entity.h"
 
 #define MAX_ENTITIES 10  // Adjustable max entities per scene
@@ -17,4 +18,5 @@ public:
 
 protected:
     ArduinoQueue<Entity*> entities;  // Safe preallocated queue
+    CollisionSystem collisionSystem;
 };


### PR DESCRIPTION
- Added CollisionSystem class to manage collision detection between entities.
- Updated Scene to maintain a CollisionSystem instance.
- Entities are now registered/unregistered with CollisionSystem on add/remove.
- Scene update now calls CollisionSystem.update() to process all collisions.
- Added a new example demonstrating the collision implementation in examples/Pong.